### PR TITLE
Use variable from pipeline.cfg

### DIFF
--- a/long_baseline_pipeline.parset
+++ b/long_baseline_pipeline.parset
@@ -65,7 +65,7 @@ pipeline.steps = [mk_results_dir, mk_calresults_dir, mk_inspect_dir, mk_ionex_di
 ! closure_phase_file            = {{ job_directory }}/closure_phases.txt ## pipeline expects this location - do not change
 
 ## Runtime setup -- will depend on your computing cluster
-! num_proc_per_node        	= 8    ## number of processes to use per step per node
+! num_proc_per_node        	= input.output.max_per_node    ## number of processes to use per step per node
 ! num_proc_per_node_limit  	= 4	## number of processes to use per step per node for tasks with high i/o (dppp or cp) or memory (eg calibration)
 ! max_dppp_threads          	= 2	## number of threads per process for NDPPP
 ! error_tolerance               = False ## False = stop if any subband fails, True = keep going


### PR DESCRIPTION
Not necessary to change the same thing in pipeline.cfg and pipeline.parset (according to cookbook)