### PR TITLE
Small fixes for download_cats.

### DIFF
--- a/LB-Delay-Calibration.parset
+++ b/LB-Delay-Calibration.parset
@@ -30,6 +30,7 @@
 ! solutions			= input.output.job_directory/solutions.h5
 ! cal_table			= combinedsols
 ! phasesol			= TGSSphase
+! continue_without_lotss = True
 
 ## Stations to flag
 ! flag_baselines                = [ ] ## for HBA data before October 2015, should set to: [ CS013HBA* ]
@@ -183,6 +184,7 @@ download_cats.control.match_tolerance           = 5.
 download_cats.control.subtract_limit            = 0.5
 download_cats.control.image_limit_Jy            = 0.05
 download_cats.control.doDownload                = {{ do_download }}
+download_cats.control.continue_no_lotss         = {{ continue_without_lotss }}
 
 ## international stations already exist in calibrator solutions but not in target phase
 ## run script to add them to necessary solution tables

--- a/plugins/PipelineStep_DownloadCats.py
+++ b/plugins/PipelineStep_DownloadCats.py
@@ -288,6 +288,7 @@ def plugin_main( args, **kwargs ):
     match_tolerance = float(kwargs['match_tolerance'])
     subtract_limit = float(kwargs['subtract_limit'])
     image_limit_Jy = float(kwargs['image_limit_Jy'])
+    fail_lotss_ok = kwargs['continue_no_lotss'].lower().capitalize()
     doDownload = kwargs['doDownload']
 
     mslist = DataMap.load(mapfile_in)
@@ -303,10 +304,12 @@ def plugin_main( args, **kwargs ):
 	    return
 	result = find_close_objs( lotss_catalogue, lbcs_catalogue, tolerance=match_tolerance ) 
         
-        if len(result) == 0:
+        if (len(result) == 0) and (fail_lotss_ok == 'True'):
             print('No cross matches found between LoTSS and LBCS! Only writing {:s}'.format(delay_cals_file))
 	    lbcs_catalogue.write(delay_cals_file, format='csv')
 	    return
+        else:
+            raise ValueError('No cross matches found between LoTSS and LBCS!')
 
         ## Need to write the following catalogues:
         ## 1 - delay calibrators -- from lbcs_catalogue
@@ -388,9 +391,10 @@ if __name__ == "__main__":
     parser.add_argument( '--subtract_limit', dest='subtract_limit', type=float, help='Flux limit for sources to subtract [Jy]', default=0.5 )
     parser.add_argument( '--bright_limit_Jy', dest='bright_limit_Jy', type=float, help='Flux limit for bright sources [Jy]', default=5.0 )
     parser.add_argument( '--image_limit_Jy', dest='image_limit_Jy', type=float, help='Flux limit for which sources to image [Jy]', default = 0.05 )
+    parser.add_argument( '--continue_no_lotss', dest='continue_no_lotss', action='store_true', help='Continue with the pipeline if no lotss cross-matches can be found?', default = False )
     parser.add_argument( 'MSname', type=str, nargs='+', help='Measurement set name (to get pointing center)' )
 
     args = parser.parse_args()
 
-    plugin_main( args.MSname, lotss_radius=args.lotss_radius, lbcs_radius=args.lbcs_radius, bright_limit_Jy=args.bright_limit_Jy, lotss_result_file=args.lotss_result_file, delay_cals_file=args.delay_cals_file, subtract_file=args.subtract_file, match_tolerance=args.match_tolerance, subtract_limit=args.subtract_limit, image_limit_Jy=args.image_limit_Jy )
+    plugin_main( args.MSname, lotss_radius=args.lotss_radius, lbcs_radius=args.lbcs_radius, bright_limit_Jy=args.bright_limit_Jy, lotss_result_file=args.lotss_result_file, delay_cals_file=args.delay_cals_file, subtract_file=args.subtract_file, match_tolerance=args.match_tolerance, subtract_limit=args.subtract_limit, image_limit_Jy=args.image_limit_Jy, continue_no_lotss = str(args.continue_no_lotss) )
 

--- a/plugins/PipelineStep_DownloadCats.py
+++ b/plugins/PipelineStep_DownloadCats.py
@@ -302,10 +302,11 @@ def plugin_main( args, **kwargs ):
 	    lbcs_catalogue.write(delay_cals_file, format='csv')
 	    return
 	result = find_close_objs( lotss_catalogue, lbcs_catalogue, tolerance=match_tolerance ) 
-
-        lotss_catalogue = my_lotss_catalogue( MSname, Radius=lotss_radius, bright_limit_Jy=bright_limit_Jy )
-        lbcs_catalogue = my_lbcs_catalogue( MSname, Radius=lbcs_radius )
-        result = find_close_objs( lotss_catalogue, lbcs_catalogue, tolerance=match_tolerance )
+        
+        if len(result) == 0:
+            print('No cross matches found between LoTSS and LBCS! Only writing {:s}'.format(delay_cals_file))
+	    lbcs_catalogue.write(delay_cals_file, format='csv')
+	    return
 
         ## Need to write the following catalogues:
         ## 1 - delay calibrators -- from lbcs_catalogue


### PR DESCRIPTION
Catch the case when no cross matches between LoTSS and LBCS are found. Remove duplicate catalogue download /crossmatch statements.