### PR TITLE
Implements #39

### DIFF
--- a/LB-Delay-Calibration.parset
+++ b/LB-Delay-Calibration.parset
@@ -44,7 +44,7 @@
 
 ! substep_ddf 			= # ,apply_ddf   ## set to apply_ddf to use, leave blank otherwise
 ! ddf_soldir			= /data/scratch/lb_bw/targetddf/L602888/SOLSDIR	 ## path to 'SOLSDIR' from ddf-pipeline run
-! delaycal_col		 	= DATA ## set to CORRECTED_DATA if applying ddf solutions
+! delaycal_col		 	= DATA_DI_CORRECTED ## set to CORRECTED_DATA if applying ddf solutions
 
 ##########################################################
 ## These parameters may need to be updated.		##
@@ -457,7 +457,7 @@ ndppp_applycal.argument.numthreads             = {{ max_dppp_threads }}
 ndppp_applycal.argument.msin                   = msfiles
 ndppp_applycal.argument.msin.datacolumn        = DATA
 ndppp_applycal.argument.msin.baseline          = *&
-ndppp_applycal.argument.msout.datacolumn       = CORRECTED_DATA	
+ndppp_applycal.argument.msout.datacolumn       = {{ delaycal_col }}
 ndppp_applycal.argument.msout.writefullresflag = False
 ndppp_applycal.argument.steps                  = [applyphase,applyamp]
 ndppp_applycal.argument.applyphase.type           = applycal
@@ -685,7 +685,7 @@ ndppp_apply_delay.control.mapfiles_in                    = [dpppconcat.output.ma
 ndppp_apply_delay.control.inputkeys                      = [inputms,h5parm]
 ndppp_apply_delay.argument.numthreads                    = {{ max_dppp_threads }}
 ndppp_apply_delay.argument.msin                          = inputms
-ndppp_apply_delay.argument.msin.datacolumn               = DATA
+ndppp_apply_delay.argument.msin.datacolumn               = {{ delaycal_col }}
 ndppp_apply_delay.argument.msin.baseline                 = *&
 ndppp_apply_delay.argument.msout.datacolumn              = CORRECTED_DATA
 ndppp_apply_delay.argument.msout.writefullresflag        = False

--- a/LB-Delay-Calibration.parset
+++ b/LB-Delay-Calibration.parset
@@ -44,7 +44,7 @@
 
 ! substep_ddf 			= # ,apply_ddf   ## set to apply_ddf to use, leave blank otherwise
 ! ddf_soldir			= /data/scratch/lb_bw/targetddf/L602888/SOLSDIR	 ## path to 'SOLSDIR' from ddf-pipeline run
-! delaycal_col		 	= DATA_DI_CORRECTED ## set to CORRECTED_DATA if applying ddf solutions
+! delaycal_col		 	= DATA ## set to DATA_DI_CORRECTED if applying ddf solutions, DATA otherwise.
 
 ##########################################################
 ## These parameters may need to be updated.		##


### PR DESCRIPTION
This allows delay calibration solutions to be applied on top of the ddf-pipeline solutions, by using the existing `delaycal_col` variable. If the `apply_ddf` substep is enabled, it will apply the ddf pipeline solutions into the `delaycal_col` column. If not using DDF solutions, this should set to DATA (default), and nothing will have to change.