### PR TITLE
fix for phase solutions with no polarization axis

### DIFF
--- a/bin/gains_toCS_h5parm.py
+++ b/bin/gains_toCS_h5parm.py
@@ -119,9 +119,14 @@ def main(h5parmfile, MSfiles, solset_in='sol000', solset_out='sol001', soltab_li
                 vals = reorderAxes(vals, soltab.getAxesNames(), ['time', 'ant'])
                 weights = reorderAxes(weights, soltab.getAxesNames(), ['time', 'ant'])
         elif 'amplitude' in soltab_name or 'phase' in soltab_name:
+          if 'pol' in soltab.getAxesNames():  
             for vals, weights, coord, selection in soltab.getValuesIter(returnAxes=['pol', 'ant', 'freq', 'time'], weight=True):
                 vals = reorderAxes(vals, soltab.getAxesNames(), ['time', 'ant', 'freq', 'pol'])
                 weights = reorderAxes(weights, soltab.getAxesNames(), ['time', 'ant', 'freq', 'pol'])
+          else: # in case we have have no polarization axis, so scalarphase-type      
+            for vals, weights, coord, selection in soltab.getValuesIter(returnAxes=['ant', 'freq', 'time'], weight=True):
+                vals = reorderAxes(vals, soltab.getAxesNames(), ['time', 'ant', 'freq'])
+                weights = reorderAxes(weights, soltab.getAxesNames(), ['time', 'ant', 'freq'])             
         else:
             logging.error('No phase or amplitude soltab has been found or specified.')
             return 1


### PR DESCRIPTION
The script could not handle phase000 solutions without polarization axis (so from a scalar type solve).
 
` soltab.getValuesIter(returnAxes=['pol', 'ant', 'freq', 'time'] `

returned an error in that case. The rest of the script was already correct catching this case checking via

` if 'pol' in soltab.getAxesNames():` 

but the case when asking for returnAxes was overlooked. I added it and verified it worked.