### PR TITLE
Fix startmod parameter to match its description

### DIFF
--- a/bin/selfcal_difmap.py
+++ b/bin/selfcal_difmap.py
@@ -782,7 +782,7 @@ if __name__ == "__main__":
     parser.add_argument("--pix_size",help="pixel size in units of mas, default 100",required=False,default=100)
     parser.add_argument("--obs_length",help="Observation length, default 900",required=False,default=900)
     parser.add_argument("--colname",type=str,help="Name of the data column. Default is CORRECTED_DATA.",required=False,default="CORRECTED_DATA")
-    parser.add_argument("--startmod",help="Generate a starting model. Default is True",required=False,action="store_false")
+    parser.add_argument("--startmod",help="Generate a starting model. Default is True",required=False,action="store_true")
     parser.add_argument("--pols",type=str,help="polarisations to self-calibrate. Default is Stokes I.",required=False,default="I")
     parser.add_argument("--catalogue",type=str,help="catalogue to help determine imaging parameters.",required=False,default=None)
     parser.add_argument("--naturalwt",type=bool,default=True)


### PR DESCRIPTION
Running `selfcal_difmap.py` standalone and passing `--startmod` currently *dis*ables generation of a starting model. This makes it match its description so that passing `--startmod` *en*ables generation of a starting model.