### PR TITLE
Circumvent h5 merge issue

### DIFF
--- a/Delay-Calibration.parset
+++ b/Delay-Calibration.parset
@@ -125,7 +125,7 @@ pipeline.steps.setup = [ mk_results_dir, mk_inspect_dir, mk_cal_values_dir, crea
 pipeline.steps.prep = [ ndppp_prep_target, ndppp_prep_target_list ]
 pipeline.steps.clipATeam   =  [ create_ateam_model_map, make_sourcedb_ateam, expand_sourcedb_ateam, predict_ateam, ateamcliptar]
 pipeline.steps.concat = [ sort_concatmap, do_sortmap_maps, dpppconcat, dpppconcat_list ]
-pipeline.steps.apply_ddf = [ createmap_ddf, ddf_solutions, ddf_h5parms, convert_to_h5, expand_concat_map, addIS, h5imp_ddf_map, h5imp_ddf, ndppp_applycal ]
+pipeline.steps.apply_ddf = [ createmap_ddf, ddf_solutions, ddf_h5parms, convert_to_h5, expand_concat_map, addIS, ndppp_applycal ]
 pipeline.steps.aoflagging = [ aoflag ]
 pipeline.steps.phaseup = [ prep_delay_dir, dppp_phaseup, dppp_phaseup_list, sort_phaseupmap, do_phaseup_maps, phaseup_concat ]
 pipeline.steps.delaycal = [ delay_cal_model, delay_solve ]
@@ -463,44 +463,25 @@ addIS.argument.solset_out           = sol001
 addIS.argument.do_int_stations      = True
 addIS.argument.flags                = [h5parms,msin]
 
-# generate a mapfile with all files in a single entry
-h5imp_ddf_map.control.kind              =   plugin
-h5imp_ddf_map.control.type              =   compressMapfile
-h5imp_ddf_map.control.mapfile_in        =   ddf_h5parms.output.mapfile
-h5imp_ddf_map.control.mapfile_dir       =   input.output.mapfile_dir
-h5imp_ddf_map.control.filename          =   h5imp_ddf_map
-
-# collect all instrument tables into one h5parm
-h5imp_ddf.control.kind                  =   recipe
-h5imp_ddf.control.type                  =   executable_args
-h5imp_ddf.control.executable            =   {{ losoto_directory }}/bin/H5parm_collector.py
-h5imp_ddf.control.error_tolerance       =   {{ error_tolerance }}
-h5imp_ddf.control.mapfile_in            =   h5imp_ddf_map.output.mapfile
-h5imp_ddf.control.inputkey              =   h5parm
-h5imp_ddf.argument.flags                =   [-v,-c,h5parm]
-h5imp_ddf.argument.outh5parm            =   {{ job_directory }}/ddf_solutions.h5
-h5imp_ddf.argument.insolset             =   sol001
-
 # apply the solutions
 ndppp_applycal.control.type                    = dppp
 ndppp_applycal.control.max_per_node            = {{ num_proc_per_node_limit }}
 ndppp_applycal.control.error_tolerance         = {{ error_tolerance }}
-ndppp_applycal.control.mapfile_in              = dpppconcat.output.mapfile
-ndppp_applycal.control.inputkey                = msfiles
+ndppp_applycal.control.mapfiles_in              = [dpppconcat.output.mapfile,ddf_h5parms.output.mapfile]
+ndppp_applycal.control.inputkeys                = [msins,parmdbs]
 ndppp_applycal.control.inplace                 = True
 ndppp_applycal.argument.numthreads             = {{ max_dppp_threads }}
-ndppp_applycal.argument.msin                   = msfiles
+ndppp_applycal.argument.msin                    = msins
 ndppp_applycal.argument.msin.datacolumn        = DATA
 ndppp_applycal.argument.msout.datacolumn       = {{ delaycal_col }}
 ndppp_applycal.argument.msout.writefullresflag = False
 ndppp_applycal.argument.msout.storagemanager   = dysco
 ndppp_applycal.argument.steps                  = [applyddf]
 ndppp_applycal.argument.applyddf.type           = applycal
-ndppp_applycal.argument.applyddf.parmdb         = {{ job_directory }}/ddf_solutions.h5
+ndppp_applycal.argument.applyddf.parmdb         = parmdbs
 ndppp_applycal.argument.applyddf.correction     = fulljones
-ndppp_applycal.argument.applyddf.solset         = sol000
+ndppp_applycal.argument.applyddf.solset         = sol001
 ndppp_applycal.argument.applyddf.soltab         = [amplitude000,phase000]
-
 ###################################################################
 ##                                                               ##
 ##              PHASEUP AND CONCATENATION                        ##


### PR DESCRIPTION
As reported in #70, merging the h5parms from the ddf solutions produces wrong solutions. This circumvents that step for the time being by applying each set to its respective block instead of attempting to merge them into a single h5parm. If I'm not mistaken Marco Bondi used this recently, so it should work on data taken with the standard LoTSS frequency setup (as the merged 2 MHz blocks should be identical between this and the ddf-pipeline).