### PR TITLE
Copy polconv.py during delay_solve

### DIFF
--- a/bin/run_selfcal.py
+++ b/bin/run_selfcal.py
@@ -38,6 +38,8 @@ def main( msin, helperscriptspath='', helperscriptspath_h5merge='', configfile='
     ## also copy the h5_merger.py script
     os.system( 'cp {:s} {:s}'.format( os.path.join( helperscriptspath_h5merge, 'h5_merger.py' ), os.path.join( destdir, 'h5_merger.py' ) ) )
 
+    os.system( 'cp {:s} {:s}'.format( os.path.join( helperscriptspath, 'polconv.py' ), os.path.join( destdir, 'polconv.py' ) ) )
+
     os.system( '/opt/lofar/pyenv-py2/bin/python {:s} {:s}'.format(os.path.join(helperscriptspath,'facetselfcal.py'), msin ) )
 
 if __name__ == "__main__":


### PR DESCRIPTION
Jurjen has added a python file that defines a DP3 step to convert polarisations. In future Singularity images this may be built in to the path but at the moment it seems safest to copy this file to the delay_solve directory along with the other files. The dp3 Python module must itself be in your PYTHONPATH for this file to work properly (implemented in spider_scripts change)